### PR TITLE
Fix npm run ok type errors

### DIFF
--- a/src/hooks/useAccountSaver.ts
+++ b/src/hooks/useAccountSaver.ts
@@ -4,6 +4,12 @@ import type { AccountData } from '../types/account.ts'
 const useAccountSaver = () => {
   const artifact = useArtifact()
 
+  if (!artifact) {
+    return async (): Promise<void> => {
+      // Artifact not ready; noop
+    }
+  }
+
   return async (data: AccountData): Promise<void> => {
     artifact.files.write.json('profile.json', data)
     await artifact.branch.write.commit('Update account data')

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -83,7 +83,7 @@ export default function useSettings() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    if (exists === null) return
+    if (!artifact || exists === null) return
     if (exists === false) {
       artifact.files.write.json('settings.json', defaultData)
       artifact.branch.write.commit('Initialize settings')
@@ -102,6 +102,7 @@ export default function useSettings() {
   const save = useCallback(
     (next: SettingsData) => {
       setData(next)
+      if (!artifact) return
       artifact.files.write.json('settings.json', next)
       artifact.branch.write.commit('Update settings')
     },


### PR DESCRIPTION
## Summary
- handle undefined artifact in `useAccountSaver`
- guard artifact access in `useSettings`

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_685252a92a88832ba25198fe3f836814